### PR TITLE
fixing argocd url in config for provider not found bug

### DIFF
--- a/argocd/overlays/rosa/configs/argo_cm/envs
+++ b/argocd/overlays/rosa/configs/argo_cm/envs
@@ -1,5 +1,5 @@
 admin.enabled=true
-url=https://console-openshift-console.apps.open-svc-sts.k1wl.p1.openshiftapps.com/
+url=https://console-openshift-console.apps.open-svc-sts.k1wl.p1.openshiftapps.com
 users.anonymous.enabled=false
 statusbadge.enabled=true
 accounts.backstage=apiKey


### PR DESCRIPTION
Issue was happening because based on the config argocd was appending the sso provider relative path to the base path which would take place when argocd ever restarted.


From the `openshift-gitops-dex-server-77488fbfc5-d6rdn` pod in namespace `openshift-gitops`:
```
time="2023-02-22T18:38:12Z" level=info msg="config issuer: https://openshift-gitops-server-openshift-gitops.apps.open-svc-sts.k1wl.p1.openshiftapps.com/api/dex"
```

This is when container starting but a few lines later it recieves a shutdown command and then it changes the route:

```
time="2023-02-22T18:38:38Z" level=info msg="config issuer: https://console-openshift-console.apps.open-svc-sts.k1wl.p1.openshiftapps.com//api/dex"
```
