### PR TITLE
removing the sealed secret for router-certs to remove argocd pruning

### DIFF
--- a/cert-manager/overlays/rosa/kustomization.yaml
+++ b/cert-manager/overlays/rosa/kustomization.yaml
@@ -2,5 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ingress-controller.yaml
-  - sealed-route-key.yaml
+  # - sealed-route-key.yaml
 


### PR DESCRIPTION
Temp fix, once it has been corrected we should track this in git.
/cc @cooktheryan 