### PR TITLE
installing the external secrets operator

### DIFF
--- a/argocd/overlays/rosa/applications/envs/rosa/cluster-management/external-secrets.yaml
+++ b/argocd/overlays/rosa/applications/envs/rosa/cluster-management/external-secrets.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: external-secrets
+spec:
+  destination:
+    name: in-cluster
+    namespace: external-secrets-operator
+  project: cluster-management
+  source:
+    path: external-secrets/overlays/rosa
+    repoURL: https://github.com/redhat-et/rosa-apps.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - Validate=false

--- a/argocd/overlays/rosa/applications/envs/rosa/cluster-management/kustomization.yaml
+++ b/argocd/overlays/rosa/applications/envs/rosa/cluster-management/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - cert-manager.yaml
   - dex.yaml
   - sealed-secrets.yaml
+  - external-secrets.yaml

--- a/cluster-scope/base/core/namespaces/external-secrets-operator/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/external-secrets-operator/kustomization.yaml
@@ -1,0 +1,7 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+namespace: external-secrets-operator
+resources:
+    - namespace.yaml
+components:
+    - ../../../../components/project-admin-rolebindings/rosa

--- a/cluster-scope/base/core/namespaces/external-secrets-operator/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/external-secrets-operator/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: external-secrets-operator
+spec: {}

--- a/cluster-scope/base/operators.coreos.com/subscriptions/external-secrets-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/external-secrets-operator/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-operators
+resources:
+- subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/external-secrets-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/external-secrets-operator/subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: external-secrets
+  namespace: openshift-operators
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: external-secrets-operator
+  source: community-operators
+  sourceNamespace: openshift-marketplace

--- a/cluster-scope/bundles/external-secrets-operator/kustomization.yaml
+++ b/cluster-scope/bundles/external-secrets-operator/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base/core/namespaces/external-secrets-operator
+  - ../../base/operators.coreos.com/subscriptions/external-secrets-operator

--- a/cluster-scope/overlays/rosa/kustomization.yaml
+++ b/cluster-scope/overlays/rosa/kustomization.yaml
@@ -44,6 +44,7 @@ resources:
   - ../../bundles/jaeger-operator
   - ../../bundles/opentelemetry-collector-operator
   - ../../bundles/tekton-chains
+  - ../../bundles/external-secrets-operator
   # --------------------------------------------------------------------------------------
   # Cluster Specific Cluster-scoped resources
   # --------------------------------------------------------------------------------------

--- a/external-secrets/base/eso.yaml
+++ b/external-secrets/base/eso.yaml
@@ -1,0 +1,114 @@
+kind: OperatorConfig
+apiVersion: operator.external-secrets.io/v1alpha1
+metadata:
+  name: rosa
+  namespace: external-secrets-operator
+spec:
+  affinity: {}
+  certController:
+    affinity: {}
+    create: true
+    deploymentAnnotations: {}
+    extraArgs: {}
+    extraEnv: []
+    fullnameOverride: ''
+    image:
+      pullPolicy: IfNotPresent
+      repository: ghcr.io/external-secrets/external-secrets
+      tag: ''
+    imagePullSecrets: []
+    nameOverride: ''
+    nodeSelector: {}
+    podAnnotations: {}
+    podLabels: {}
+    podSecurityContext: {}
+    priorityClassName: ''
+    prometheus:
+      enabled: false
+      service:
+        port: 8080
+    rbac:
+      create: true
+    requeueInterval: 5m
+    resources: {}
+    securityContext: {}
+    serviceAccount:
+      annotations: {}
+      create: true
+      name: ''
+    tolerations: []
+  concurrent: 1
+  controllerClass: ''
+  crds:
+    createClusterExternalSecret: true
+    createClusterSecretStore: true
+  createOperator: true
+  deploymentAnnotations: {}
+  extraArgs: {}
+  extraEnv: []
+  fullnameOverride: ''
+  image:
+    pullPolicy: IfNotPresent
+    repository: ghcr.io/external-secrets/external-secrets
+    tag: ''
+  imagePullSecrets: []
+  installCRDs: false
+  leaderElect: false
+  nameOverride: ''
+  nodeSelector: {}
+  podAnnotations: {}
+  podLabels: {}
+  podSecurityContext: {}
+  priorityClassName: ''
+  processClusterExternalSecret: true
+  processClusterStore: true
+  prometheus:
+    enabled: false
+    service:
+      port: 8080
+  rbac:
+    create: true
+  replicaCount: 1
+  resources: {}
+  scopedNamespace: ''
+  scopedRBAC: false
+  securityContext: {}
+  serviceAccount:
+    annotations: {}
+    create: true
+    name: ''
+  tolerations: []
+  webhook:
+    affinity: {}
+    certCheckInterval: 5m
+    certDir: /tmp/certs
+    create: true
+    deploymentAnnotations: {}
+    extraArgs: {}
+    extraEnv: []
+    fullnameOverride: ''
+    image:
+      pullPolicy: IfNotPresent
+      repository: ghcr.io/external-secrets/external-secrets
+      tag: ''
+    imagePullSecrets: []
+    nameOverride: ''
+    nodeSelector: {}
+    podAnnotations: {}
+    podLabels: {}
+    podSecurityContext: {}
+    priorityClassName: ''
+    prometheus:
+      enabled: false
+      service:
+        port: 8080
+    rbac:
+      create: true
+    replicaCount: 1
+    resources: {}
+    securityContext: {}
+    serviceAccount:
+      annotations: {}
+      create: true
+      name: ''
+    tolerations: []

--- a/external-secrets/base/kustomization.yaml
+++ b/external-secrets/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - eso.yaml

--- a/external-secrets/overlays/rosa/kustomization.yaml
+++ b/external-secrets/overlays/rosa/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: external-secrets-operator
+resources:
+  - ../../base


### PR DESCRIPTION
Installing the External secrets operator. This PR was generated from the op1st instalation as a base, see [subscriptions pr](https://github.com/operate-first/apps/pull/1732/files) and [deployment PR](https://github.com/operate-first/apps/pull/1983/files).
/cc @cooktheryan 