### PR TITLE
third round obserability operators bugfixes

### DIFF
--- a/cluster-scope/base/operators.coreos.com/operatorgroups/tempo-operator/operatorgroup.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/tempo-operator/operatorgroup.yaml
@@ -3,6 +3,4 @@ apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
   name: tempo-operator
-spec:
-  targetNamespaces:
-    - tempo-operator
+spec: {}

--- a/cluster-scope/base/operators.coreos.com/subscriptions/loki-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/loki-operator/subscription.yaml
@@ -1,8 +1,8 @@
----
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: loki-operator
+  namespace: openshift-operators-redhat
 spec:
   channel: stable
   installPlanApproval: Automatic

--- a/cluster-scope/base/operators.coreos.com/subscriptions/minio-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/minio-operator/subscription.yaml
@@ -3,6 +3,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: minio-operator
+  namespace: openshift-operators
 spec:
   channel: stable
   installPlanApproval: Automatic

--- a/cluster-scope/base/operators.coreos.com/subscriptions/observability-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/observability-operator/subscription.yaml
@@ -3,6 +3,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: observability-operator
+  namespace: openshift-operators
 spec:
   channel: stable
   config:

--- a/cluster-scope/base/operators.coreos.com/subscriptions/tempo-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/tempo-operator/subscription.yaml
@@ -3,6 +3,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: tempo-operator
+  namespace: tempo-operator
 spec:
   channel: alpha
   name: tempo-operator


### PR DESCRIPTION
changes include: remove `targetnamespace` from tempo operator group, confining operator subscriptions to specified namespaces.