### PR TITLE
installing the external secrets operator

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/external-secrets-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/external-secrets-operator/subscription.yaml
@@ -1,7 +1,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  name: external-secrets
+  name: external-secrets-operator
   namespace: openshift-operators
 spec:
   channel: alpha
@@ -9,3 +9,4 @@ spec:
   name: external-secrets-operator
   source: community-operators
   sourceNamespace: openshift-marketplace
+  startingCSV: external-secrets-operator.v0.8.1


### PR DESCRIPTION
updating git to match live deployment name and verison. Self megering as its only naming / starting csv for preinstalled operator changes.