### PR TITLE
keeping kustomize build namespace the same as subscription (openshift-operators)

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/minio-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/minio-operator/kustomization.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: minio-operator
+namespace: openshift-operators
 resources:
 - subscription.yaml


### PR DESCRIPTION
bug fix for argocd sync, similar to: #42 