### PR TITLE
bugfixes for Certmanager and OTEL

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/cert-manager/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/cert-manager/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: openshift-operators
 resources:
 - subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/opentelemetry-collector-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/opentelemetry-collector-operator/kustomization.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: openshift-operators
+namespace: opentelemetry-collector-operator
 resources:
 - subscription.yaml

--- a/cluster-scope/bundles/opentelemetry-collector-operator/kustomization.yaml
+++ b/cluster-scope/bundles/opentelemetry-collector-operator/kustomization.yaml
@@ -2,6 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: opentelemetry-collector-operator
 resources:
-  - ../../base/core/namespaces/openshift-distributed-tracing
   - ../../base/operators.coreos.com/subscriptions/opentelemetry-collector-operator
   - ../../base/operators.coreos.com/operatorgroups/opentelemetry-collector-operator

--- a/cluster-scope/overlays/rosa/kustomization.yaml
+++ b/cluster-scope/overlays/rosa/kustomization.yaml
@@ -57,6 +57,7 @@ resources:
   - ../../bundles/cert-manager
   - ../../bundles/tekton-chains
   - ../../bundles/external-secrets-operator
+  - ../../bundles/opentelemetry-collector-operator
   - ../../bundles/vault
   # --------------------------------------------------------------------------------------
   # Cluster Specific Cluster-scoped resources


### PR DESCRIPTION
changes:
- unify certamanger operator namespaces
- remove distrubted tracing ns from otel bundle
- deploy otel bundle