### PR TITLE
fix: tempo catalog source

### DIFF
--- a/cluster-scope/base/operators.coreos.com/catalogsources/tempo-operator/catalogsource.yaml
+++ b/cluster-scope/base/operators.coreos.com/catalogsources/tempo-operator/catalogsource.yaml
@@ -5,6 +5,6 @@ metadata:
   name: tempo-operator-catalog
 spec:
   displayName: Tempo Operator Catalog
-  image: ghcr.io/frzifus/tempo-operator:openshift-6d2b16d
+  image: ghcr.io/frzifus/tempo-operator/tempo-operator-catalog:v0.0.9
   publisher: Tempo Operator Authors
   sourceType: grpc


### PR DESCRIPTION
This is a fresh build of https://github.com/os-observability/tempo-operator/commit/5ec7feaa09e5f4ce224732a148b1ca334c841d0c fixing the operator installation.

cc @sallyom