### PR TITLE
creating argocd-notifications webhook for triggering nexodus e2e-qa workflow

### DIFF
--- a/argocd-notifications/base/configmap.yaml
+++ b/argocd-notifications/base/configmap.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-notifications-cm
+data:
+  context: "argocdUrl:"
+  trigger.on-sync-succeeded: |
+    - when: app.status.operationState.phase in ['Succeeded'] and repo.FullNameByRepoURL(app.spec.source.repoURL) == 'nexodus-io/nexodus'
+      description: Application syncing has succeeded
+      send: [github-json]
+  service.webhook.github: |
+    url: https://api.github.com
+    headers:
+    - name: "Accept"
+      value: "application/vnd.github+json"
+    - name: "Authorization"
+      value: "token $argocd-token"
+  template.github-json: |
+    webhook:
+      github: 
+        method: POST
+        path: /{{call .repo.FullNameByRepoURL .app.spec.source.repoURL}}/dispatches
+        body: |
+          {
+            "ARGOCD_APP_NAME": "{{.app.metadata.name}}",
+            "ARGOCD_SYNC_STATUS": "{{.app.status.sync.status}}",
+            "ARGOCD_APP_BRANCH": "{{.app.spec.source.targetRevision}}",
+            "ARGOCD_SYNC_REVISION": "{{.app.status.sync.revision}}",
+            "ARGOCD_GIT_URL": "{{.app.spec.source.repoURL}}"
+          }

--- a/argocd-notifications/base/kustomization.yaml
+++ b/argocd-notifications/base/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: argocd
+
+resources:
+- 'https://raw.githubusercontent.com/argoproj-labs/argocd-notifications/v1.2.0/manifests/install.yaml'
+patchesStrategicMerge:
+- configmap.yaml

--- a/argocd-notifications/overlays/rosa/argocd-notifications-secret.yaml
+++ b/argocd-notifications/overlays/rosa/argocd-notifications-secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: argocd-notifications-secret
+spec:
+  secretStoreRef:
+    name: vault-store
+    kind: SecretStore
+  target:
+    name: argocd-notifications-secret
+  dataFrom:
+    - extract:
+        key: rosa/openshift-gitops/argocd-notifications-secret

--- a/argocd-notifications/overlays/rosa/kustomization.yaml
+++ b/argocd-notifications/overlays/rosa/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+  - argocd-notifications-secret.yaml
+
+patches:
+  - target:
+      kind: ConfigMap
+      name: argocd-notifications-cm
+    patch: |
+      - op: add
+        path: /data/context
+        value: "argocdUrl: http://openshift-gitops-server-openshift-gitops.apps.open-svc-sts.k1wl.p1.openshiftapps.com/"


### PR DESCRIPTION
Addresses part of https://github.com/nexodus-io/nexodus/issues/548
action items:
- External secret needs to be created with bearer token for nexodus-io/nexodus with correct scopes and stored in vault

Depends on:
- Vault unseal 2 worker nodes and join raft
- Fixing vault kubernetes auth method
- deploying secret store to nexodus namespaces
- text kuberenetes cluster has vault connectivity and can provision external secrets

Changes on the nexodus side:
add `repository-dispatch` to e2e github workflow.