### PR TITLE
make sure cluster resources builds

### DIFF
--- a/cluster-scope/overlays/rosa/groups/cluster-admins.yaml
+++ b/cluster-scope/overlays/rosa/groups/cluster-admins.yaml
@@ -1,0 +1,13 @@
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+  name: cluster-admins
+users:
+  - cooktheryan
+  - sallyom
+  - sabre1041
+  - RobotSail
+  - Gregory-Pereira
+  - cluster-admin
+  - lkatalin
+  - frzifus

--- a/cluster-scope/overlays/rosa/kustomization.yaml
+++ b/cluster-scope/overlays/rosa/kustomization.yaml
@@ -60,12 +60,13 @@ resources:
   - ../../bundles/external-secrets-operator
   - ../../bundles/vault
   - ../../bundles/grafana-operator
-  - ../../bundles/openshfit-serverless
+  - ../../bundles/openshift-serverless
   # --------------------------------------------------------------------------------------
   # Cluster Specific Cluster-scoped resources
   # --------------------------------------------------------------------------------------
   - apiserver/api_server_cert.yaml
   - clusterversion.yaml
+  - groups/cluster-admins.yaml
   - ingresscontrollers/default.yaml
 
 patchesStrategicMerge:


### PR DESCRIPTION
argocd failing to sync because bundle was referenced incorrectly in the kustomization overlay.

Also adding cluster-admins as a Gitops group, and removing it from hive management by removing the annotation.