### PR TITLE
removing sealed secret for vault keyshards

### DIFF
--- a/vault/overlays/rosa/kustomization.yaml
+++ b/vault/overlays/rosa/kustomization.yaml
@@ -4,5 +4,5 @@ resources:
   - ../../base
   # - backup-job
   # - obc.yaml
-  - sealed-secrets
+  # - sealed-secrets
 namespace: vault


### PR DESCRIPTION
Bug fix, will enable argocd vault app sync.

reasons: secret already exists in cluster and argocd lacks permissions to deploy sealed secrets in rosa project.