### PR TITLE
rbac: Make prometheus-monitoring a ClusterRole

### DIFF
--- a/cluster-scope/components/monitoring-rbac/monitoring-role.yaml
+++ b/cluster-scope/components/monitoring-rbac/monitoring-role.yaml
@@ -1,5 +1,5 @@
 ---
-kind: Role
+kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: prometheus-monitoring

--- a/cluster-scope/components/monitoring-rbac/monitoring-rolebinding.yaml
+++ b/cluster-scope/components/monitoring-rbac/monitoring-rolebinding.yaml
@@ -9,5 +9,5 @@ subjects:
     namespace: rosa-monitoring
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: prometheus-monitoring


### PR DESCRIPTION
I'm hoping that this will allow a projects that is using the Prometheus Operator to create a RoleBinding in their own namespaces. For example, in Nexodus I'd create a ServiceAccount prometheus... and 2 role bindings, one to bind this ClusterRole to nexodus and another to nexodus-qa.