### PR TITLE
Add a temporary keycloak instance as a Fulcio OIDC issuer

### DIFF
--- a/sigstore/base/values.yaml
+++ b/sigstore/base/values.yaml
@@ -41,6 +41,10 @@ fulcio:
         : IssuerURL: https://rh-oidc.s3.us-east-1.amazonaws.com/21o4ml1f5kchd6ee9nmh5dhc6efqba38
           ClientID: sigstore
           Type: kubernetes
+        ? https://keycloak.sigstore-keycloak-test.com/realms/sigstore
+        : IssuerURL: https://keycloak.sigstore-keycloak-test.com/realms/sigstore
+          ClientID: sigstore
+          Type: email
 
 tuf:
   namespace:


### PR DESCRIPTION
cc @sallyom @lkatalin 

Add my Keycloak testing instance as a workaround waiting for Keycloak to be deployed on this cluster.

I didn't test this configuration yet so please let me know if I should change anything (or if we should go for another approach), and how I could proceed with testing if we want to have it.

Also, don't hesitate to ping me if you would be interested in using this Keycloak instance, I can onboard you with accessing the admin interface and configuring clients.