### PR TITLE
add rhsso-operator to keycloak-system and add sigstore keycloak resources

### DIFF
--- a/cluster-scope/base/core/namespaces/keycloak-system/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/keycloak-system/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- namespace.yaml
+namespace: keycloak-system
+components:
+- ../../../../components/limitranges/default
+- ../../../../components/resourcequotas/large

--- a/cluster-scope/base/core/namespaces/keycloak-system/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/keycloak-system/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: keycloak-system
+    annotations:
+        openshift.io/requester: octo-et-platform

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/keycloak-system/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/keycloak-system/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: keycloak-system
 resources:
-  #- tuf-root-secret-sealed.yaml
-  - ../keycloak
-  - ../../base
+    - operatorgroup.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/keycloak-system/operatorgroup.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/keycloak-system/operatorgroup.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: keycloak-system
+spec:
+  targetNamespaces:
+  - keycloak-system

--- a/cluster-scope/base/operators.coreos.com/subscriptions/rhsso-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/rhsso-operator/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: keycloak-system
 resources:
-  #- tuf-root-secret-sealed.yaml
-  - ../keycloak
-  - ../../base
+    - subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/rhsso-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/rhsso-operator/subscription.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+    name: rhsso-operator
+spec:
+    channel: stable
+    installPlanApproval: Automatic
+    name: rhsso-operator
+    source: redhat-operators
+    sourceNamespace: openshift-marketplace

--- a/cluster-scope/bundles/rhsso-operator/kustomization.yaml
+++ b/cluster-scope/bundles/rhsso-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base/operators.coreos.com/operatorgroups/keycloak-system
+  - ../../base/operators.coreos.com/subscriptions/rhsso-operator

--- a/sigstore/overlays/keycloak/keycloak.yaml
+++ b/sigstore/overlays/keycloak/keycloak.yaml
@@ -1,0 +1,17 @@
+apiVersion: keycloak.org/v1alpha1
+kind: Keycloak
+metadata:
+  labels:
+    app: sso
+  name: keycloak
+spec:
+  http:
+    httpEnabled: true
+    tlsSecret: sso-x509-https-secret
+  externalAccess:
+    enabled: true
+  instances: 1
+  keycloakDeploymentSpec:
+    imagePullPolicy: Always
+  postgresDeploymentSpec:
+    imagePullPolicy: Always

--- a/sigstore/overlays/keycloak/kustomization.yaml
+++ b/sigstore/overlays/keycloak/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: keycloak-system
+
+resources:
+- keycloak.yaml
+- realm.yaml
+- sigstore-client.yaml
+- user.yaml

--- a/sigstore/overlays/keycloak/realm.yaml
+++ b/sigstore/overlays/keycloak/realm.yaml
@@ -1,0 +1,16 @@
+apiVersion: keycloak.org/v1alpha1
+kind: KeycloakRealm
+metadata:
+  labels:
+    app: sso
+  name: sigstore
+  namespace: keycloak-system
+spec:
+  instanceSelector:
+    matchLabels:
+      app: sso
+  realm:
+    displayName: Sigstore
+    enabled: true
+    id: sigstore
+    realm: sigstore

--- a/sigstore/overlays/keycloak/sigstore-client.yaml
+++ b/sigstore/overlays/keycloak/sigstore-client.yaml
@@ -1,0 +1,55 @@
+apiVersion: keycloak.org/v1alpha1
+kind: KeycloakClient
+metadata:
+  labels:
+    app: sso
+  name: sigstore
+  namespace: keycloak-system
+spec:
+  client:
+    attributes:
+      request.object.signature.alg: RS256
+      user.info.response.signature.alg: RS256
+    clientAuthenticatorType: client-secret
+    clientId: sigstore
+    defaultClientScopes:
+    - profile
+    - email
+    description: Client for Sigstore authentication
+    directAccessGrantsEnabled: true
+    implicitFlowEnabled: false
+    name: sigstore
+    protocol: openid-connect
+    protocolMappers:
+    - config:
+        claim.name: email
+        id.token.claim: "true"
+        jsonType.label: String
+        user.attribute: email
+        userinfo.token.claim: "true"
+      name: email
+      protocol: openid-connect
+      protocolMapper: oidc-usermodel-property-mapper
+    - config:
+        claim.name: email-verified
+        id.token.claim: "true"
+        user.attribute: emailVerified
+        userinfo.token.claim: "true"
+      name: email-verified
+      protocol: openid-connect
+      protocolMapper: oidc-usermodel-property-mapper
+    - config:
+        claim.name: aud
+        claim.value: sigstore
+        id.token.claim: "true"
+        userinfo.token.claim: "true"
+      name: audience
+      protocol: openid-connect
+      protocolMapper: oidc-hardcoded-claim-mapper
+    publicClient: true
+    standardFlowEnabled: true
+    redirectUris:
+    - "*"
+  realmSelector:
+    matchLabels:
+      app: sso

--- a/sigstore/overlays/keycloak/user.yaml
+++ b/sigstore/overlays/keycloak/user.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: keycloak.org/v1alpha1
+kind: KeycloakUser
+metadata:
+  labels:
+    app: sso
+  name: jdoe
+  namespace: keycloak-system
+spec:
+  realmSelector:
+    matchLabels:
+      app: sso
+  user:
+    email: jdoe@redhat.com
+    enabled: true
+    emailVerified: true
+    credentials:
+      - type: password
+        value: secure
+    firstName: Jane
+    lastName: Doe
+    username: jdoe


### PR DESCRIPTION
@Gregory-Pereira ptal, updated!

This reflects what is currently deployed

1) adds rhsso-operator subscription 
2) creates keycloak-system ns
3) creates operatorgroup for keycloak-system
4) creates keycloak resources overlay for sigstore 

/cc @mayaCostantini  you can add the sigstore-confidential realm as a follow-up

When this merges, we can remove the other keycloak in `-n keycloak` and update fulcio config OIDC urls to point to new keycloak in `-n keycloak-system` 