### PR TITLE
Nexodus project needs a new namespace

### DIFF
--- a/cluster-scope/base/core/namespaces/nexodus-playground/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/nexodus-playground/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- namespace.yaml
+- ../../../../components/project-admin-rolebindings/nexodus
+namespace: nexodus-playground
+components:
+- ../../../../components/limitranges/default
+- ../../../../components/resourcequotas/x-large

--- a/cluster-scope/base/core/namespaces/nexodus-playground/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/nexodus-playground/namespace.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    op1st/docs: https://github.com/nexodus-io/nexodus
+    op1st/onboarding-issue: https://github.com/operate-first/support/issues/1143
+    op1st/project-owner: russellb
+    openshift.io/display-name: nexodus-playground
+    openshift.io/requester: vishnoianil
+  name: nexodus-playground


### PR DESCRIPTION
to try out solutions for the issues
they are encountrying during nexodus scale testing.

QA is used by our CI jobs, so we can not use that to try out these solutions.

Nexodus stack deployed in this namespace will
be experimental and unstable.